### PR TITLE
fix: add crypto.getRandomValues polyfill for uuid support

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,9 @@
  * @format
  */
 
+// Polyfill for crypto.getRandomValues() - must be imported BEFORE uuid
+import 'react-native-get-random-values';
+
 import { AppRegistry } from 'react-native';
 import App from './App';
 import { name as appName } from './app.json';

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "react": "19.2.0",
         "react-native": "0.83.0",
         "react-native-gesture-handler": "^2.29.1",
+        "react-native-get-random-values": "^2.0.0",
         "react-native-reanimated": "^4.2.0",
         "react-native-safe-area-context": "^5.5.2",
         "react-native-screens": "^4.19.0",
@@ -6451,6 +6452,12 @@
       "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
       "license": "Apache-2.0"
     },
+    "node_modules/fast-base64-decode": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-base64-decode/-/fast-base64-decode-1.0.0.tgz",
+      "integrity": "sha512-qwaScUgUGBYeDNRnbc/KyllVU88Jk1pRHPStuF/lO7B0/RTRLj7U0lkdTAutlBblY08rwZDff6tNU9cjv6j//Q==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -10384,6 +10391,18 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-get-random-values": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-native-get-random-values/-/react-native-get-random-values-2.0.0.tgz",
+      "integrity": "sha512-wx7/aPqsUIiWsG35D+MsUJd8ij96e3JKddklSdrdZUrheTx89gPtz3Q2yl9knBArj5u26Cl23T88ai+Q0vypdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-base64-decode": "^1.0.0"
+      },
+      "peerDependencies": {
+        "react-native": ">=0.81"
       }
     },
     "node_modules/react-native-is-edge-to-edge": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react": "19.2.0",
     "react-native": "0.83.0",
     "react-native-gesture-handler": "^2.29.1",
+    "react-native-get-random-values": "^2.0.0",
     "react-native-reanimated": "^4.2.0",
     "react-native-safe-area-context": "^5.5.2",
     "react-native-screens": "^4.19.0",


### PR DESCRIPTION
The uuid library requires crypto.getRandomValues() which is not available by default in React Native. This adds the react-native-get-random-values polyfill imported at the app entry point before any uuid imports.

Fixes: crypto.getRandomValues() not supported error on session complete